### PR TITLE
Handle null results from babel.transformFileAsync

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ async function transform({
 
 	const filesToCompile = [];
 	const filesToCopy = [];
+	const ignoredFilesToCopy = [];
 	const filesToRemove = [];
 
 	// Filter source files between files to copy or compile
@@ -80,7 +81,7 @@ async function transform({
 		const mtimeDest = await mtime(destFile);
 		if (mtimeDest < mtimeSrc) {
 			if (extensions.some((extension) => srcFile.endsWith(extension))) {
-				filesToCompile.push(srcFile);
+				filesToCompile.push([srcFile, destFile]);
 			}
 			else if (copyOthers) {
 				filesToCopy.push([srcFile, destFile]);
@@ -130,15 +131,15 @@ async function transform({
 		sourceMaps,
 	};
 
-	await pMap(filesToCompile, async (srcFile) => {
-		let destFile = `${destDir}/${srcFile.substring(srcDir.length + 1)}`;
-		destFile = `${destFile.slice(0, destFile.length - path.extname(destFile).length)}.js`;
+	await pMap(filesToCompile, async ([srcFile, destFile]) => {
 		const result = await babel.transformFileAsync(srcFile, options);
 
-		// files can be ignored from babel config
 		if (!result) {
+			ignoredFilesToCopy.push([srcFile, destFile]);
 			return;
 		}
+
+		destFile = `${destFile.slice(0, destFile.length - path.extname(destFile).length)}.js`;
 
 		if (sourceMaps) {
 			result.code += `\n//# sourceMappingURL=${destFile}.map`;
@@ -152,6 +153,14 @@ async function transform({
 			await write(`${destFile}.map`, JSON.stringify(result.map));
 		}
 	}, {concurrency: 5});
+
+	if (ignoredFilesToCopy.length) {
+		logger.log(`[babel] copying ${ignoredFilesToCopy.length} ignored files`);
+		await pMap(ignoredFilesToCopy, async ([src, dest]) => {
+			await mkdirp(dest);
+			await fs.copyFile(src, dest);
+		});
+	}
 
 	logger.timeEnd('babel-changed');
 }

--- a/index.js
+++ b/index.js
@@ -135,6 +135,11 @@ async function transform({
 		destFile = `${destFile.slice(0, destFile.length - path.extname(destFile).length)}.js`;
 		const result = await babel.transformFileAsync(srcFile, options);
 
+		// files can be ignored from babel config
+		if (!result) {
+			return;
+		}
+
 		if (sourceMaps) {
 			result.code += `\n//# sourceMappingURL=${destFile}.map`;
 		}

--- a/index.js
+++ b/index.js
@@ -135,9 +135,7 @@ async function transform({
 		const result = await babel.transformFileAsync(srcFile, options);
 
 		if (!result) {
-			if (copyOthers) {
-				ignoredFilesToCopy.push([srcFile, destFile]);
-			}
+			ignoredFilesToCopy.push([srcFile, destFile]);
 			return;
 		}
 
@@ -157,11 +155,16 @@ async function transform({
 	}, {concurrency: 5});
 
 	if (ignoredFilesToCopy.length) {
-		logger.log(`[babel] ${ignoredFilesToCopy.length} files expected to be compiled but are ignored by babel config. Copying them unmodified.`);
-		await pMap(ignoredFilesToCopy, async ([src, dest]) => {
-			await mkdirp(dest);
-			await fs.copyFile(src, dest);
-		});
+		if (copyOthers) {
+			logger.log(`[babel] ${ignoredFilesToCopy.length} files expected to be compiled but are ignored by babel config. Copying them unmodified.`);
+			await pMap(ignoredFilesToCopy, async ([src, dest]) => {
+				await mkdirp(dest);
+				await fs.copyFile(src, dest);
+			});
+		}
+		else {
+			logger.log(`[babel] ${ignoredFilesToCopy.length} files expected to be compiled but are ignored by babel config.`);
+		}
 	}
 
 	logger.timeEnd('babel-changed');

--- a/index.js
+++ b/index.js
@@ -135,7 +135,9 @@ async function transform({
 		const result = await babel.transformFileAsync(srcFile, options);
 
 		if (!result) {
-			ignoredFilesToCopy.push([srcFile, destFile]);
+			if (copyOthers) {
+				ignoredFilesToCopy.push([srcFile, destFile]);
+			}
 			return;
 		}
 
@@ -155,7 +157,7 @@ async function transform({
 	}, {concurrency: 5});
 
 	if (ignoredFilesToCopy.length) {
-		logger.log(`[babel] copying ${ignoredFilesToCopy.length} ignored files`);
+		logger.log(`[babel] ${ignoredFilesToCopy.length} files expected to be compiled but are ignored by babel config. Copying them unmodified.`);
 		await pMap(ignoredFilesToCopy, async ([src, dest]) => {
 			await mkdirp(dest);
 			await fs.copyFile(src, dest);


### PR DESCRIPTION
If the file is ignored in babel config, but not ignored via `ignore-glob`, `babel.transformFileAsync` will return null.