### PR TITLE
Fixed typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ async function transform({
 	const destFiles = (await fastGlob(filesGlobPattern, {
 		cwd: destDir,
 		absolute: true,
-	}).map(path.normalize);
+	})).map(path.normalize);
 
 	const filesToCompile = [];
 	const filesToCopy = [];


### PR DESCRIPTION
There's a paren missing and triggering a Syntax Error in babel-changed@0.6.0